### PR TITLE
Dynamic refresh of chat list

### DIFF
--- a/app/src/main/java/com/disarm/sanna/pdm/Util/PathFileObserver.java
+++ b/app/src/main/java/com/disarm/sanna/pdm/Util/PathFileObserver.java
@@ -4,6 +4,8 @@ import android.os.FileObserver;
 import android.util.Log;
 import android.widget.Toast;
 
+import com.disarm.sanna.pdm.SocialShareActivity;
+
 import java.io.File;
 
 /**
@@ -16,6 +18,7 @@ public class PathFileObserver extends FileObserver {
      * should be end with File.separator
      */
     String rootPath;
+    SocialShareActivity socialShareActivity;
     static final int mask = (FileObserver.CREATE |
             FileObserver.DELETE |
             FileObserver.DELETE_SELF |
@@ -24,12 +27,14 @@ public class PathFileObserver extends FileObserver {
             FileObserver.MOVED_TO |
             FileObserver.MOVE_SELF);
 
-    public PathFileObserver(String path) {
+    public PathFileObserver(SocialShareActivity activity, String path) {
         super(path, mask);
         if (! path.endsWith(File.separator)){
             path += File.separator;
         }
         rootPath = path;
+
+        socialShareActivity = activity;
     }
 
     @Override
@@ -52,6 +57,9 @@ public class PathFileObserver extends FileObserver {
                 break;
             case FileObserver.MOVED_TO:
                 Log.d(TAG, "MOVED_TO:" + path);
+
+                File file = new File(rootPath + path);
+                socialShareActivity.refreshList(rootPath + path, file);
                 break;
             case FileObserver.MOVE_SELF:
                 Log.d(TAG, "MOVE_SELF:" + path);


### PR DESCRIPTION
Not tested on multiple devices.

SocialShareActivity list will be dynamically refreshed. Sent or received files corresponding to a chat will be visible only after launching ShareActivitty from SocialShareActivity, ie, ShareActivitty list is not dynamically  refreshed. 
