### PR TITLE
Improve Layout of Social Sharing app for all screen sizes

### DIFF
--- a/app/src/main/java/com/disarm/sanna/pdm/SocialShareActivity.java
+++ b/app/src/main/java/com/disarm/sanna/pdm/SocialShareActivity.java
@@ -143,8 +143,7 @@ public class SocialShareActivity extends AppCompatActivity implements View.OnCli
         pathFileObserver.startWatching();
         
         startServices();
-        Button exit = (Button)findViewById(R.id.b_social_share_exit);
-        exit.setOnClickListener(this);
+
         FloatingActionButton addChat = (FloatingActionButton) findViewById(R.id.b_social_share_add);
         addChat.setOnClickListener(this);
         requestLocation();
@@ -408,9 +407,6 @@ public class SocialShareActivity extends AppCompatActivity implements View.OnCli
     @Override
     public void onClick(View view) {
         switch (view.getId()) {
-            case R.id.b_social_share_exit:
-                stopServices();
-                break;
             case R.id.b_social_share_add:
                 final AlertDialog.Builder addNewChat = new AlertDialog.Builder(this);
                 addNewChat.setTitle("Add New");

--- a/app/src/main/java/com/disarm/sanna/pdm/SocialShareActivity.java
+++ b/app/src/main/java/com/disarm/sanna/pdm/SocialShareActivity.java
@@ -14,6 +14,7 @@ import android.location.LocationManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
+import android.os.Handler;
 import android.os.IBinder;
 import android.provider.BaseColumns;
 import android.provider.ContactsContract;
@@ -80,6 +81,8 @@ public class SocialShareActivity extends AppCompatActivity implements View.OnCli
 
     SocialShareChatlistAdapter chatlistAdapter;
 
+    private boolean doubleBackToExitPressedOnce;
+
     //Psync
     private ServiceConnection syncServiceConnection = new ServiceConnection() {
 
@@ -129,6 +132,8 @@ public class SocialShareActivity extends AppCompatActivity implements View.OnCli
         senders = new ArrayList<>();
 
         setTitle("Recent");
+
+        doubleBackToExitPressedOnce = false;
 
         myself = new Senders(identifySelf(), "Me");
         populateChatList();
@@ -458,6 +463,7 @@ public class SocialShareActivity extends AppCompatActivity implements View.OnCli
     protected void onDestroy() {
         super.onDestroy();
         pathFileObserver.stopWatching();
+        stopServices();
     }
 
     private void requestLocation(){
@@ -565,5 +571,25 @@ public class SocialShareActivity extends AppCompatActivity implements View.OnCli
                 });
         AlertDialog alert = alertDialogBuilder.create();
         alert.show();
+    }
+
+    @Override
+    public void onBackPressed() {
+        if(doubleBackToExitPressedOnce) {
+            super.onBackPressed();
+            stopServices();
+            return;
+        }
+
+        doubleBackToExitPressedOnce = true;
+        Toast.makeText(this, R.string.press_back_to_exit, Toast.LENGTH_SHORT).show();
+
+        new Handler().postDelayed(new Runnable() {
+
+            @Override
+            public void run() {
+                doubleBackToExitPressedOnce=false;
+            }
+        }, 2000);
     }
 }

--- a/app/src/main/res/layout/frag_choose_cat_bar.xml
+++ b/app/src/main/res/layout/frag_choose_cat_bar.xml
@@ -21,7 +21,7 @@
             android:src="@drawable/camera_burst"
             app:elevation="3dp"
             app:backgroundTint="@android:color/darker_gray"
-            android:layout_weight="0.21"/>
+            android:layout_weight="0.2"/>
 
         <android.support.design.widget.FloatingActionButton
             android:id="@+id/sh_video"
@@ -32,7 +32,7 @@
             android:src="@drawable/message_video"
             app:elevation="3dp"
             app:backgroundTint="@android:color/darker_gray"
-            android:layout_weight="0.21"/>
+            android:layout_weight="0.2"/>
 
         <android.support.design.widget.FloatingActionButton
             android:id="@+id/sh_audio"
@@ -43,7 +43,7 @@
             android:src="@drawable/audiobook"
             app:elevation="3dp"
             app:backgroundTint="@android:color/darker_gray"
-            android:layout_weight="0.21"/>
+            android:layout_weight="0.2"/>
 
         <android.support.design.widget.FloatingActionButton
             android:id="@+id/sh_text"
@@ -54,7 +54,7 @@
             android:src="@drawable/format_text"
             app:elevation="3dp"
             app:backgroundTint="@android:color/darker_gray"
-            android:layout_weight="0.21"/>
+            android:layout_weight="0.2"/>
 
         <android.support.design.widget.FloatingActionButton
             android:id="@+id/sh_sms"
@@ -65,7 +65,7 @@
             android:src="@drawable/tooltip_text"
             app:elevation="3dp"
             app:backgroundTint="@android:color/darker_gray"
-            />
+            android:layout_weight="0.2"/>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/layout_social_share.xml
+++ b/app/src/main/res/layout/layout_social_share.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    >
+    android:layout_height="match_parent">
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/list_social_share_chats"
@@ -11,24 +10,18 @@
         android:scrollbars="vertical"
         android:layout_marginLeft="5dp"
         android:layout_marginRight="5dp"
+        android:layout_alignParentBottom="true"
         android:layout_alignParentTop="true" />
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/b_social_share_add"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_gravity="bottom|end"
         android:src="@android:drawable/ic_input_add"
         android:layout_marginLeft="@dimen/fab_margin"
         android:layout_marginRight="@dimen/fab_margin"
-        android:layout_alignTop="@+id/b_social_share_exit"
-        android:layout_alignEnd="@+id/list_social_share_chats" />
-
-    <Button
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Exit"
-        android:id="@+id/b_social_share_exit"
         android:layout_alignParentBottom="true"
-        android:layout_alignStart="@+id/list_social_share_chats" />
+        android:layout_alignParentEnd="true" />
+
 </RelativeLayout>

--- a/app/src/main/res/layout/share_activity.xml
+++ b/app/src/main/res/layout/share_activity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -7,27 +7,32 @@
     android:weightSum="100"
     android:baselineAligned="false">
 
-    <include layout="@layout/frag_choose_cat_bar"/>
-
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:id="@+id/linearLayout2"
-        android:background="#BABABA"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentStart="true">
+        android:layout_weight="5"
+        android:id="@+id/linearLayout1"
+        android:background="#BABABA">
 
-        <include layout="@layout/frag_send_bar"/>
-
+        <include layout="@layout/frag_choose_cat_bar" />
     </LinearLayout>
 
     <ListView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:id="@+id/share_received_files"
-        android:layout_alignParentStart="true"
-        android:layout_above="@+id/linearLayout2"
-        android:layout_below="@+id/cat_but">
+        android:layout_weight="90"
+        android:id="@+id/share_received_files">
     </ListView>
-</RelativeLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_weight="5"
+        android:id="@+id/linearLayout2"
+        android:background="#BABABA">
+
+        <include layout="@layout/frag_send_bar"/>
+    </LinearLayout>
+</LinearLayout>


### PR DESCRIPTION
1. Removed the Exit Button in SocialShareActivity. Services will now be closed on double pressing back button.
2. Used Relative layout for both layouts of SocialShareActivity and ShareActivity. It should resolve most of the bugs related to various screen sizes. 
